### PR TITLE
yada-17 fix gradle depreciation warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     runtime('com.h2database:h2')
     runtime('org.postgresql:postgresql')
 
-    compileOnly('org.springframework.boot:spring-boot-configuration-processor')
+    annotationProcessor('org.springframework.boot:spring-boot-configuration-processor')
     testCompile('org.springframework.boot:spring-boot-starter-test')
     testCompile('org.springframework.security:spring-security-test')
 }


### PR DESCRIPTION
With Gradle 4.6 and later, the dependency should be declared in the
annotationProcessor configuration, as shown in the following example: